### PR TITLE
Vesting denominator change

### DIFF
--- a/src/StakedCitadelVester.sol
+++ b/src/StakedCitadelVester.sol
@@ -118,7 +118,7 @@ contract StakedCitadelVester is
                     locked.mul(
                         block.timestamp.sub(vesting[recipient].unlockBegin)
                     )
-                ).div(vestingDuration)
+                ).div(vesting[recipient].unlockEnd - vesting[recipient].unlockBegin)
             ).sub(claimed);
     }
 


### PR DESCRIPTION
Fix for vesting denominator based on following initial feedback (more thorough review incoming later this week):

Suppose a user locks some tokens and the current vesting period is 86400 * 21. Now suppose the governance comes in and updates the vestingDuration to be 86400 * 10. If the user calls claim while the vesting is still active (lets say a couple seconds before the vesting ends), then the calculation of claimableBalance will use the updated vestingDuration, which will result in the user being transferred more tokens than they deserve (since block.timestamp.sub(vesting[recipient].unlockBegin) divided by vestingDuration will be larger than 1).

So whenever the vestingDuration is updated, users will either receive fewer tokens than they deserve (if vestingDuration increases) or too many tokens (if vestingDuration decreases). This could be a rug-pull vector by the governance if they want to steal vesting tokens, or just an accidental mistake that causes problems.

In order to mitigate this issue, I think claimableBalance should divide by vesting[recipient].unlockEnd - vesting[recipient].unlockBegin instead of vestingDuration.