### PR TITLE
some more optimizations after alex PR

### DIFF
--- a/src/CitadelMinter.sol
+++ b/src/CitadelMinter.sol
@@ -248,9 +248,7 @@ contract CitadelMinter is
         // Remove existing pool on 0 weight
         if (_weight == 0 && poolExists) {
             fundingPoolWeights[_pool] = 0;
-            totalFundingPoolWeight =
-                totalFundingPoolWeight -
-                fundingPoolWeights[_pool];
+            //subtracting 0 doesn't change anything
             _removeFundingPool(_pool);
 
             emit FundingPoolWeightSet(_pool, _weight, totalFundingPoolWeight);
@@ -260,11 +258,8 @@ contract CitadelMinter is
             if (!poolExists) {
                 _addFundingPool(_pool);
             }
-            uint256 _newTotalWeight = totalFundingPoolWeight;
-            _newTotalWeight = _newTotalWeight - fundingPoolWeights[_pool];
-            fundingPoolWeights[_pool] = _weight;
-            _newTotalWeight = _newTotalWeight + _weight;
-            totalFundingPoolWeight = _newTotalWeight;
+            // can we just use the same variable `totalFundingPoolWeight` and emit the same?
+            uint256 _newTotalWeight = totalFundingPoolWeight - fundingPoolWeights[_pool] + _weight;
 
             emit FundingPoolWeightSet(_pool, _weight, _newTotalWeight);
         }

--- a/src/KnightingRound.sol
+++ b/src/KnightingRound.sol
@@ -170,7 +170,7 @@ contract KnightingRound is GlobalAccessControlManaged {
             block.timestamp < saleStart + saleDuration,
             "KnightingRound: already ended"
         );
-        require(_tokenInAmount > 0, "_tokenInAmount should be > 0");
+        require(_tokenInAmount != 0, "_tokenInAmount should be > 0");
         require(
             totalTokenIn.add(_tokenInAmount) <= tokenInLimit,
             "total amount exceeded"
@@ -182,7 +182,7 @@ contract KnightingRound is GlobalAccessControlManaged {
 
         uint256 boughtAmountTillNow = boughtAmounts[msg.sender];
 
-        if (boughtAmountTillNow > 0) {
+        if (boughtAmountTillNow != 0) {
             require(
                 _daoId == daoVotedFor[msg.sender],
                 "can't vote for multiple daos"
@@ -213,7 +213,7 @@ contract KnightingRound is GlobalAccessControlManaged {
 
         tokenOutAmount_ = boughtAmounts[msg.sender];
 
-        require(tokenOutAmount_ > 0, "nothing to claim");
+        require(tokenOutAmount_ != 0, "nothing to claim");
 
         hasClaimed[msg.sender] = true;
         totalTokenOutClaimed = totalTokenOutClaimed.add(tokenOutAmount_);
@@ -410,7 +410,7 @@ contract KnightingRound is GlobalAccessControlManaged {
             amount = amount.sub(amountLeftToBeClaimed);
         }
 
-        require(amount > 0, "nothing to sweep");
+        require(amount != 0, "nothing to sweep");
 
         ERC20Upgradeable(_token).safeTransfer(saleRecipient, amount);
 


### PR DESCRIPTION
Some more minor optimizations :

CitadelMinter.sol 
- L#251 - subtracting 0 doesn't change anything
- L#263 to 267 can be optimised as `totalFundingPoolWeight = totalFundingPoolWeight - fundingPoolWeights[_pool] + _weight;` if no new var is used

Funding.sol
- Cache xCitadel like in CitadelMinter.sol (as per alex PR) for deposit()
- L#169, 303,321,399(similar) - _assetAmountIn !=0 in require statement being unsigned int

KnightingRound.sol
- L#173,185,216,413 - prefer !=0 in require statement being unsigned int

StakedCitadel.sol
- L#344,369,783,794 - use calldata instead of memory for proof, similar to KnightingRound.sol L#166 (TODO? , PR after going through again)