### PR TITLE
feat: removing the safemath for 0.8.*

### DIFF
--- a/src/Funding.sol
+++ b/src/Funding.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.12;
 
-import {SafeMathUpgradeable} from "openzeppelin-contracts-upgradeable/utils/math/SafeMathUpgradeable.sol";
 import {SafeERC20Upgradeable} from "openzeppelin-contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
 import {ReentrancyGuardUpgradeable} from "openzeppelin-contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
 
@@ -15,7 +14,6 @@ import "./lib/SafeERC20.sol";
  * TODO: Better revert strings
  */
 contract Funding is GlobalAccessControlManaged, ReentrancyGuardUpgradeable {
-    using SafeMathUpgradeable for uint256;
     using SafeERC20 for IERC20;
 
     // Roles used from GAC
@@ -168,8 +166,7 @@ contract Funding is GlobalAccessControlManaged, ReentrancyGuardUpgradeable {
     {
         require(_assetAmountIn > 0, "_assetAmountIn must not be 0");
         require(
-            funding.assetCumulativeFunded.add(_assetAmountIn) <=
-                funding.assetCap,
+            funding.assetCumulativeFunded + _assetAmountIn <= funding.assetCap,
             "asset funding cap exceeded"
         );
 
@@ -227,7 +224,7 @@ contract Funding is GlobalAccessControlManaged, ReentrancyGuardUpgradeable {
         uint256 assetCumulativeFunded = funding.assetCumulativeFunded;
         uint256 assetCap = funding.assetCap;
         if (assetCumulativeFunded < assetCap) {
-            limitLeft_ = assetCap.sub(assetCumulativeFunded);
+            limitLeft_ = assetCap - assetCumulativeFunded;
         }
     }
 

--- a/src/GlobalAccessControl.sol
+++ b/src/GlobalAccessControl.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.0;
 pragma experimental ABIEncoderV2;
 
 import {IERC20Upgradeable} from "openzeppelin-contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol"; 
-import {SafeMathUpgradeable} from "openzeppelin-contracts-upgradeable/utils/math/SafeMathUpgradeable.sol";
 import {SafeERC20Upgradeable} from "openzeppelin-contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
 import {PausableUpgradeable} from "openzeppelin-contracts-upgradeable/security/PausableUpgradeable.sol";
 import {AccessControlEnumerableUpgradeable} from "openzeppelin-contracts-upgradeable/access/AccessControlEnumerableUpgradeable.sol";
@@ -22,7 +21,6 @@ contract GlobalAccessControl is
     PausableUpgradeable
 {
     using SafeERC20Upgradeable for IERC20Upgradeable;
-    using SafeMathUpgradeable for uint256;
 
     bytes32 public constant CONTRACT_GOVERNANCE_ROLE =
         keccak256("CONTRACT_GOVERNANCE_ROLE");

--- a/src/StakedCitadel.sol
+++ b/src/StakedCitadel.sol
@@ -904,9 +904,7 @@ contract StakedCitadel is
 
         // Management fee is calculated against the assets before harvest, to make it fair to depositors
         uint256 management_fee = managementFee > 0
-            ? managementFee *
-                balance() -
-                (_harvestedAmount * duration) /
+            ? (managementFee * (balance() - _harvestedAmount) * duration) /
                 SECS_PER_YEAR /
                 MAX_BPS
             : 0;

--- a/src/StakedCitadelVester.sol
+++ b/src/StakedCitadelVester.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.12;
 
 import {IERC20Upgradeable} from "openzeppelin-contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
-import {SafeMathUpgradeable} from "openzeppelin-contracts-upgradeable/utils/math/SafeMathUpgradeable.sol";
 import {SafeERC20Upgradeable} from "openzeppelin-contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
 import {ReentrancyGuardUpgradeable} from "openzeppelin-contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
 
@@ -16,7 +15,6 @@ contract StakedCitadelVester is
     GlobalAccessControlManaged,
     ReentrancyGuardUpgradeable
 {
-    using SafeMathUpgradeable for uint256;
     using SafeERC20Upgradeable for IERC20Upgradeable;
 
     bytes32 public constant CONTRACT_GOVERNANCE_ROLE =
@@ -89,9 +87,9 @@ contract StakedCitadelVester is
             amount = claimable;
         }
         if (amount != 0) {
-            vesting[msg.sender].claimedAmounts = vesting[msg.sender]
-                .claimedAmounts
-                .add(amount);
+            vesting[msg.sender].claimedAmounts =
+                vesting[msg.sender].claimedAmounts +
+                amount;
             vestingToken.safeTransfer(recipient, amount);
             emit Claimed(msg.sender, recipient, amount);
         }
@@ -110,16 +108,12 @@ contract StakedCitadelVester is
         uint256 locked = vesting[recipient].lockedAmounts;
         uint256 claimed = vesting[recipient].claimedAmounts;
         if (block.timestamp >= vesting[recipient].unlockEnd) {
-            return locked.sub(claimed);
+            return locked - claimed;
         }
         return
-            (
-                (
-                    locked.mul(
-                        block.timestamp.sub(vesting[recipient].unlockBegin)
-                    )
-                ).div(vesting[recipient].unlockEnd - vesting[recipient].unlockBegin)
-            ).sub(claimed);
+            ((locked * (block.timestamp - vesting[recipient].unlockBegin)) /
+                (vesting[recipient].unlockEnd -
+                    vesting[recipient].unlockBegin)) - claimed;
     }
 
     /// =========================
@@ -142,11 +136,11 @@ contract StakedCitadelVester is
         require(msg.sender == vault, "StakedCitadelVester: only xCTDL vault");
         require(_amount > 0, "StakedCitadelVester: cannot vest 0");
 
-        vesting[recipient].lockedAmounts = vesting[recipient].lockedAmounts.add(
-            _amount
-        );
+        vesting[recipient].lockedAmounts =
+            vesting[recipient].lockedAmounts +
+            _amount;
         vesting[recipient].unlockBegin = _unlockBegin;
-        vesting[recipient].unlockEnd = _unlockBegin.add(vestingDuration);
+        vesting[recipient].unlockEnd = _unlockBegin + vestingDuration;
 
         emit Vest(
             recipient,

--- a/src/SupplySchedule.sol
+++ b/src/SupplySchedule.sol
@@ -6,7 +6,6 @@ import "ds-test/test.sol";
 import {IERC20Upgradeable} from "openzeppelin-contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import {ERC20Upgradeable} from "openzeppelin-contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
 import {MathUpgradeable} from "openzeppelin-contracts-upgradeable/utils/math/MathUpgradeable.sol";
-import {SafeMathUpgradeable} from "openzeppelin-contracts-upgradeable/utils/math/SafeMathUpgradeable.sol";
 import {AddressUpgradeable} from "openzeppelin-contracts-upgradeable/utils/AddressUpgradeable.sol";
 import {PausableUpgradeable} from "openzeppelin-contracts-upgradeable/security/PausableUpgradeable.sol";
 import {SafeERC20Upgradeable} from "openzeppelin-contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";

--- a/src/test/BaseFixture.sol
+++ b/src/test/BaseFixture.sol
@@ -8,7 +8,6 @@ import {Utils} from "./utils/Utils.sol";
 import {ERC20Utils} from "./utils/ERC20Utils.sol";
 import {SnapshotComparator} from "./utils/SnapshotUtils.sol";
 
-import {SafeMathUpgradeable} from "openzeppelin-contracts-upgradeable/utils/math/SafeMathUpgradeable.sol";
 import {GlobalAccessControl} from "../GlobalAccessControl.sol";
 
 import {CitadelToken} from "../CitadelToken.sol";
@@ -26,7 +25,6 @@ import "../interfaces/erc20/IERC20.sol";
 import "../interfaces/badger/IEmptyStrategy.sol";
 
 contract BaseFixture is DSTest, Utils {
-    using SafeMathUpgradeable for uint256;
     Vm constant vm = Vm(HEVM_ADDRESS);
     ERC20Utils immutable erc20utils = new ERC20Utils();
     SnapshotComparator comparator;


### PR DESCRIPTION
Since Solidity 0.8, the overflow/underflow check is implemented on the language level, We don't need SafeMath anymore.

Close #15 