### PR TITLE
fix the command of the script in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Hardhat Ganace is more reliable than ganache itself for UI testing so we provide
 This will be run the deploy script on default network, but don't be shy to use other hardhat options for it
 
 ```
-npx hardhat run scripts/deploy-local.js
+npx hardhat run scripts/deploy-local.js --network localhost
 ```
 
 # System Overview


### PR DESCRIPTION
changed the README of running the script from 

```
npx hardhat run scripts/deploy-local.js
```

to 

```
npx hardhat run scripts/deploy-local.js --network localhost
```

this should fix the front end team running into some exceptions