### PR TITLE
fix behavior on multiple setupVesting calls

### DIFF
--- a/src/StakedCitadelVester.sol
+++ b/src/StakedCitadelVester.sol
@@ -137,6 +137,9 @@ contract StakedCitadelVester is
         require(msg.sender == vault, "StakedCitadelVester: only xCTDL vault");
         require(_amount > 0, "StakedCitadelVester: cannot vest 0");
 
+        vesting[recipient].lockedAmounts -= vesting[recipient].claimedAmounts;
+        vesting[recipient].claimedAmounts = 0;
+
         vesting[recipient].lockedAmounts =
             vesting[recipient].lockedAmounts +
             _amount;


### PR DESCRIPTION
Based on feedback from the peer review.

**Problem:** Consider a scenario where a user withdraws 100 tokens, and these fully vest and are claimed. After all this, imagine the same user withdraws an additional 100 tokens. Halfway through the vesting of these new 100 tokens, the calculation of `claimableBalance`:
```
function claimableBalance(address recipient) public view returns (uint256) {
    uint256 locked = vesting[recipient].lockedAmounts;
    uint256 claimed = vesting[recipient].claimedAmounts;
    if (block.timestamp >= vesting[recipient].unlockEnd) {
        return locked - claimed;
    }
    return
        ((locked * (block.timestamp - vesting[recipient].unlockBegin)) /
            (vesting[recipient].unlockEnd -
                vesting[recipient].unlockBegin)) - claimed;
}
```
will return `(200*0.5) - 100 = 0`, meaning that the vesting won't actually have started until halfway through the unlock period, which is clearly incorrect. In this scenario, if the user had tried to claim any of their vesting before the halfway-point, the transaction would revert. The more withdraws that a user does, the worse this problem gets, as `claimedAmounts` will increase to be quite large relative to the amount that still remains to be vested. 

**Fix:** Whenever `setupVesting` is called, it should essentially set-up the variables as if it were an entirely new vesting period. To do this, we should decrement the `lockedAmounts` variable by `claimedAmounts`, and set `claimedAmounts` to 0. Following the above example, after `setupVesting` is called with the new 100 tokens, `lockedAmounts` will be set as 100, and `claimedAmounts` will be set as 0, which will lead to correct behavior. 

Another example we can consider is if `setupVesting` is called part-way through an existing vesting. For example, in the above example if the original vesting period was instead 75% complete (so locked = 100, claimed = 75) before adding the new 100 tokens, then the result of `setupVesting` 100 new tokens would be locked = (100 - 75) + 100 = 125, claimed = 0, which makes sense as well (essentially, the 25 tokens that have not vested yet should be carried over to the new vesting period).