### PR TITLE
Fixed Foundry compiler errors and added Testing CI Workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,22 @@
+name: Tests
+
+on: [push, pull_request]
+
+jobs:
+  check:
+    name: Foundry project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+
+      - name: Run tests
+        run: forge test --fork-url https://eth-mainnet.alchemyapi.io/v2/${{ secrets.ALCHEMY_KEY }} -vvv
+      
+

--- a/src/mocks/CVX.sol
+++ b/src/mocks/CVX.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
-import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
+import "openzeppelin-contracts/token/ERC20/ERC20.sol";
+import "openzeppelin-contracts/access/Ownable.sol";
 
 contract Convex is ERC20 {
     constructor() ERC20("Convex", "CVX") {}

--- a/src/mocks/USDC.sol
+++ b/src/mocks/USDC.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
-import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
+import "openzeppelin-contracts/token/ERC20/ERC20.sol";
+import "openzeppelin-contracts/access/Ownable.sol";
 
 contract USDC is ERC20 {
     constructor() ERC20("USD Coin", "USDC") {}

--- a/src/mocks/wBTC.sol
+++ b/src/mocks/wBTC.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
-import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
+import "openzeppelin-contracts/token/ERC20/ERC20.sol";
+import "openzeppelin-contracts/access/Ownable.sol";
 
 contract WrapBitcoin is ERC20 {
     constructor() ERC20("Wrapped Bitcoin", "wBTC") {}


### PR DESCRIPTION
The imports paths within the mock tokens were not in agreement with Foundry's remaps and, hence, compilation is failing for tests. Changed paths and now all contracts compile. Hardhat.config has a job that adjusts all paths to the localtion of Hardhat's deps, which allows for compilation for scripts.

Foundry compilation:
![image](https://user-images.githubusercontent.com/25463788/164520878-2331fa94-c438-466b-927d-1188393a826d.png)

Hardhat compilation: 
![image](https://user-images.githubusercontent.com/25463788/164520916-a5a9786c-570f-453f-a639-86ec128e6e4f.png)

Both successful.

A github workflow as also added to run all tests upon PR and Push to avoid broking commits in the future. 

Reference: https://github.com/foundry-rs/foundry-toolchain