### PR TITLE
Allow keeper role for mintAndDistribute

### DIFF
--- a/src/CitadelMinter.sol
+++ b/src/CitadelMinter.sol
@@ -33,6 +33,8 @@ contract CitadelMinter is
         keccak256("POLICY_OPERATIONS_ROLE");
     bytes32 public constant TREASURY_GOVERNANCE_ROLE =
         keccak256("TREASURY_GOVERNANCE_ROLE");
+    bytes32 public constant KEEPER_ROLE = 
+        keccak256("KEEPER_ROLE");
 
     bytes32 public constant XCITADEL_LOCKER_EMISSIONS = keccak256("xcitadel-locker-emissions");
 
@@ -169,13 +171,20 @@ contract CitadelMinter is
     /// ===== Policy Ops actions =====
     /// ==============================
 
+    function getMintAndDistributeRoles() internal pure returns (bytes32[] memory) {
+        bytes32[] memory roles = new bytes32[](2);
+        roles[0] = POLICY_OPERATIONS_ROLE;
+        roles[1] = KEEPER_ROLE;
+        return roles;
+    }
+
     /**
      * @notice Update the state of citadel emissions by minting and distributing citadel tokens according to the emission schedule and proportional splits between destinations (e.g. funding pools, stakers, lockers)
      * @dev In theory this call should be permissionless, and after sufficient security analysis this may be changed to be the case
      */
     function mintAndDistribute()
         external
-        onlyRole(POLICY_OPERATIONS_ROLE)
+        onlyRoles(getMintAndDistributeRoles())
         gacPausable
         nonReentrant
     {

--- a/src/test/Minting.t.sol
+++ b/src/test/Minting.t.sol
@@ -132,34 +132,51 @@ contract MintingTest is BaseFixture {
     ) public {
         uint HALF_MAX_BPS = 5000;
         vm.assume(bps_A <= HALF_MAX_BPS && bps_B <= HALF_MAX_BPS);
-        _testMintAndDistribute(bps_A, HALF_MAX_BPS - bps_A, bps_B, HALF_MAX_BPS - bps_B);
+        _testMintAndDistribute(bps_A, HALF_MAX_BPS - bps_A, bps_B, HALF_MAX_BPS - bps_B, governance);
     }
 
     function testMintAndDistribute_SpecialCases() public {
-        _testMintAndDistribute(10000, 0, 0, 0);
+        _testMintAndDistribute(10000, 0, 0, 0, governance);
         vm.warp(block.timestamp + 1000);
-        _testMintAndDistribute(0, 10000, 0, 0);
+        _testMintAndDistribute(0, 10000, 0, 0, governance);
         vm.warp(block.timestamp + 1000);
-        _testMintAndDistribute(0, 0, 10000, 0);
+        _testMintAndDistribute(0, 0, 10000, 0, governance);
         vm.warp(block.timestamp + 1000);
-        _testMintAndDistribute(0, 0, 0, 10000);
+        _testMintAndDistribute(0, 0, 0, 10000, governance);
         vm.warp(block.timestamp + 1000);
-        _testMintAndDistribute(2500, 2500, 2500, 2500);
+        _testMintAndDistribute(2500, 2500, 2500, 2500, governance);
         vm.warp(block.timestamp + 1000);
-        _testMintAndDistribute(5000, 0, 0, 5000);
+        _testMintAndDistribute(5000, 0, 0, 5000, governance);
         vm.warp(block.timestamp + 1000);
-        _testMintAndDistribute(1, 1, 1, 9997);
+        _testMintAndDistribute(1, 1, 1, 9997, governance);
+    }
+
+    function testMintAndDistributeKeeper() public {
+        _testMintAndDistribute(10000, 0, 0, 0, keeper);
+        vm.warp(block.timestamp + 1000);
+        _testMintAndDistribute(0, 10000, 0, 0, keeper);
+        vm.warp(block.timestamp + 1000);
+        _testMintAndDistribute(0, 0, 10000, 0, keeper);
+        vm.warp(block.timestamp + 1000);
+        _testMintAndDistribute(0, 0, 0, 10000, keeper);
+        vm.warp(block.timestamp + 1000);
+        _testMintAndDistribute(2500, 2500, 2500, 2500, keeper);
+        vm.warp(block.timestamp + 1000);
+        _testMintAndDistribute(5000, 0, 0, 5000, keeper);
+        vm.warp(block.timestamp + 1000);
+        _testMintAndDistribute(1, 1, 1, 9997, keeper);
     }
 
     function _testMintAndDistribute(
         uint256 _bps_A,
         uint256 _bps_B,
         uint256 _bps_C,
-        uint256 _bps_D
+        uint256 _bps_D,
+        address mintingAddress
     ) public {
         TestInfo memory info;
         // Initialize minting timestamp
-        vm.startPrank(governance);
+        vm.startPrank(mintingAddress);
         if (schedule.globalStartTimestamp() == 0) {
             schedule.setMintingStart(block.timestamp);
             citadelMinter.initializeLastMintTimestamp();


### PR DESCRIPTION
Changes for issue  #125.

I currently create a bytes32[] through an internal function. There didn't seem to be an easier approach of generating bytes32[].

Another option:
Create a new function like `onlyTwoRoles` in `GlobalAccessControlManaged` that takes two roles as params so we don't need to keep calling `getMintAndDistributeRoles` every time `mintAndDistribute` is called.

@dapp-whisperer @sajanrajdev let me know what you think