### PR TITLE
Extend prettier formatting to subdirectories

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,15 +16,12 @@ jobs:
           submodules: recursive
 
       - name: Use Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
             node-version: '16.x'
 
       - name: Install Dependencies
         run: npm install
 
-      - name: Run prettier check
-        run: npm run prettier:solidity:check
-
-      - name: Run linter check
+      - name: Run linter/formatting checks
         run: npm run solhint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,10 @@
 name: Linter
 
-on: [push, pull_request]
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches: [main]
 
 jobs:
   check:
@@ -19,7 +23,8 @@ jobs:
       - name: Install Dependencies
         run: npm install
 
-      - name: Run linter/formatter check
+      - name: Run prettier check
+        run: npm run prettier:solidity:check
+
+      - name: Run linter check
         run: npm run solhint
-
-

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "scripts": {
     "solhint": "solhint -f table 'src/**/*.sol'",
     "prettier:solidity": "prettier --write 'src/**/*.sol'",
-    "prettier:solidity:check": "prettier --check 'src/**/*.sol'",
     "prepare": "husky install",
     "gen-types": "./gen-types.sh"
   }

--- a/package.json
+++ b/package.json
@@ -22,8 +22,9 @@
     "moment": "^2.29.3"
   },
   "scripts": {
-    "solhint": "./node_modules/.bin/solhint -f table src/**/*.sol",
-    "prettier:solidity": "./node_modules/.bin/prettier --write src/**/*.sol",
+    "solhint": "solhint -f table 'src/**/*.sol'",
+    "prettier:solidity": "prettier --write 'src/**/*.sol'",
+    "prettier:solidity:check": "prettier --check 'src/**/*.sol'",
     "prepare": "husky install",
     "gen-types": "./gen-types.sh"
   }

--- a/src/BrickedStrategy.sol
+++ b/src/BrickedStrategy.sol
@@ -22,7 +22,13 @@ contract BrickedStrategy is BaseStrategy {
     /// @dev Return a list of protected tokens
     /// @notice It's very important all tokens that are meant to be in the strategy to be marked as protected
     /// @notice this provides security guarantees to the depositors they can't be sweeped away
-    function getProtectedTokens() public view virtual override returns (address[] memory) {
+    function getProtectedTokens()
+        public
+        view
+        virtual
+        override
+        returns (address[] memory)
+    {
         address[] memory protectedTokens = new address[](1);
         protectedTokens[0] = want;
         return protectedTokens;
@@ -42,18 +48,25 @@ contract BrickedStrategy is BaseStrategy {
 
     /// @dev Withdraw `_amount` of want, so that it can be sent to the vault / depositor
     /// @notice just unlock the funds and return the amount you could unlock
-    function _withdrawSome(uint256 _amount) internal override returns (uint256) {
+    function _withdrawSome(uint256 _amount)
+        internal
+        override
+        returns (uint256)
+    {
         // No-op
         return _amount;
     }
 
-
     /// @dev Does this function require `tend` to be called?
-    function _isTendable() internal override pure returns (bool) {
+    function _isTendable() internal pure override returns (bool) {
         return false; // Change to true if the strategy should be tended
     }
 
-    function _harvest() internal override returns (TokenAmount[] memory harvested) {
+    function _harvest()
+        internal
+        override
+        returns (TokenAmount[] memory harvested)
+    {
         // No-op as we don't do anything with funds
 
         // Nothing harvested, we have 2 tokens, return both 0s
@@ -66,9 +79,8 @@ contract BrickedStrategy is BaseStrategy {
         return harvested;
     }
 
-
     // Example tend is a no-op which returns the values, could also just revert
-    function _tend() internal override returns (TokenAmount[] memory tended){
+    function _tend() internal override returns (TokenAmount[] memory tended) {
         // Nothing tended
         tended = new TokenAmount[](1);
         tended[0] = TokenAmount(want, 0);
@@ -83,7 +95,12 @@ contract BrickedStrategy is BaseStrategy {
 
     /// @dev Return the balance of rewards that the strategy has accrued
     /// @notice Used for offChain APY and Harvest Health monitoring
-    function balanceOfRewards() external view override returns (TokenAmount[] memory rewards) {
+    function balanceOfRewards()
+        external
+        view
+        override
+        returns (TokenAmount[] memory rewards)
+    {
         // Rewards are 0
         rewards = new TokenAmount[](1);
         rewards[0] = TokenAmount(want, 0);

--- a/src/CitadelMinter.sol
+++ b/src/CitadelMinter.sol
@@ -34,7 +34,8 @@ contract CitadelMinter is
     bytes32 public constant TREASURY_GOVERNANCE_ROLE =
         keccak256("TREASURY_GOVERNANCE_ROLE");
 
-    bytes32 public constant XCITADEL_LOCKER_EMISSIONS = keccak256("xcitadel-locker-emissions");
+    bytes32 public constant XCITADEL_LOCKER_EMISSIONS =
+        keccak256("xcitadel-locker-emissions");
 
     ICitadelToken public citadelToken;
     IVault public xCitadel;
@@ -137,10 +138,16 @@ contract CitadelMinter is
 
         // Approve xCitadel vault for use of citadel tokens
         // NOTE: Using input params as those cost 3 to read vs 100 from storage
-        IERC20Upgradeable(_citadelToken).safeApprove(_xCitadel, type(uint256).max);
+        IERC20Upgradeable(_citadelToken).safeApprove(
+            _xCitadel,
+            type(uint256).max
+        );
 
         // Approve xCitadel for locker to use
-        IERC20Upgradeable(_xCitadel).safeApprove(_xCitadelLocker, type(uint256).max);
+        IERC20Upgradeable(_xCitadel).safeApprove(
+            _xCitadelLocker,
+            type(uint256).max
+        );
     }
 
     /// =======================
@@ -231,7 +238,10 @@ contract CitadelMinter is
         if (cachedStakingBps != 0) {
             stakingAmount = (mintable * cachedStakingBps) / MAX_BPS;
 
-            IERC20Upgradeable(address(citadelToken)).safeTransfer(address(cachedXCitadel), stakingAmount);
+            IERC20Upgradeable(address(citadelToken)).safeTransfer(
+                address(cachedXCitadel),
+                stakingAmount
+            );
             emit CitadelDistributionToStaking(
                 cachedLastMintTimestamp,
                 block.timestamp,
@@ -251,15 +261,25 @@ contract CitadelMinter is
         }
 
         if (cachedDaoBps != 0) {
-
             // Note: will revert if no treasury governance role set. Assumes only a single member for this role which should be enforced on GAC.
-            address treasuryVault = gac.getRoleMember(TREASURY_GOVERNANCE_ROLE, 0);
+            address treasuryVault = gac.getRoleMember(
+                TREASURY_GOVERNANCE_ROLE,
+                0
+            );
 
             daoAmount = (mintable * cachedDaoBps) / MAX_BPS;
-            IERC20Upgradeable(address(citadelToken)).safeTransfer(treasuryVault, daoAmount);
+            IERC20Upgradeable(address(citadelToken)).safeTransfer(
+                treasuryVault,
+                daoAmount
+            );
         }
 
-        emit CitadelDistribution(fundingAmount, stakingAmount, lockingAmount, daoAmount);
+        emit CitadelDistribution(
+            fundingAmount,
+            stakingAmount,
+            lockingAmount,
+            daoAmount
+        );
 
         lastMintTimestamp = block.timestamp;
     }
@@ -331,7 +351,12 @@ contract CitadelMinter is
         lockingBps = _lockingBps;
         daoBps = _daoBps;
 
-        emit CitadelDistributionSplitSet(_fundingBps, _stakingBps, _lockingBps, _daoBps);
+        emit CitadelDistributionSplitSet(
+            _fundingBps,
+            _stakingBps,
+            _lockingBps,
+            _daoBps
+        );
     }
 
     /// ==============================

--- a/src/Funding.sol
+++ b/src/Funding.sol
@@ -22,7 +22,8 @@ contract Funding is GlobalAccessControlManaged, ReentrancyGuardUpgradeable {
         keccak256("CONTRACT_GOVERNANCE_ROLE");
     bytes32 public constant POLICY_OPERATIONS_ROLE =
         keccak256("POLICY_OPERATIONS_ROLE");
-    bytes32 public constant TREASURY_OPERATIONS_ROLE = keccak256("TREASURY_OPERATIONS_ROLE");
+    bytes32 public constant TREASURY_OPERATIONS_ROLE =
+        keccak256("TREASURY_OPERATIONS_ROLE");
     bytes32 public constant KEEPER_ROLE = keccak256("KEEPER_ROLE");
 
     uint256 public constant MAX_BPS = 10000;
@@ -109,14 +110,8 @@ contract Funding is GlobalAccessControlManaged, ReentrancyGuardUpgradeable {
         address _citadelPerAssetOracle,
         uint256 _assetCap
     ) external initializer {
-        require(
-            _saleRecipient != address(0),
-            "Funding: 0 sale"
-        );
-        require(
-            _citadelPerAssetOracle != address(0),
-            "Funding: 0 oracle"
-        );
+        require(_saleRecipient != address(0), "Funding: 0 sale");
+        require(_citadelPerAssetOracle != address(0), "Funding: 0 oracle");
 
         __GlobalAccessControlManaged_init(_gac);
         __ReentrancyGuard_init();
@@ -171,22 +166,20 @@ contract Funding is GlobalAccessControlManaged, ReentrancyGuardUpgradeable {
             funding.assetCumulativeFunded + _assetAmountIn <= funding.assetCap,
             "asset funding cap exceeded"
         );
-        funding.assetCumulativeFunded = funding.assetCumulativeFunded + _assetAmountIn;
+        funding.assetCumulativeFunded =
+            funding.assetCumulativeFunded +
+            _assetAmountIn;
         // Take in asset from user
         citadelAmount_ = getAmountOut(_assetAmountIn);
         require(citadelAmount_ >= _minCitadelOut, "minCitadelOut");
 
         asset.safeTransferFrom(msg.sender, saleRecipient, _assetAmountIn);
-        
+
         // Deposit xCitadel and send to user
         // TODO: Check gas costs. How does this relate to market buying if you do want to deposit to xCTDL?
         xCitadel.depositFor(msg.sender, citadelAmount_);
 
-        emit Deposit(
-            msg.sender,
-            _assetAmountIn,
-            citadelAmount_
-        );
+        emit Deposit(msg.sender, _assetAmountIn, citadelAmount_);
     }
 
     /// =======================
@@ -222,9 +215,15 @@ contract Funding is GlobalAccessControlManaged, ReentrancyGuardUpgradeable {
      * @param _assetAmountIn Amount of `asset` to exchange
      * @return xCitadelAmount_ Amount of `xCitadel` received at current price per share
      */
-    function getStakedCitadelAmountOut(uint256 _assetAmountIn) public view returns (uint256 xCitadelAmount_) {
-        uint citadelAmount = getAmountOut(_assetAmountIn);
-        xCitadelAmount_ = citadelAmount * ONE_ETH / xCitadel.getPricePerFullShare();
+    function getStakedCitadelAmountOut(uint256 _assetAmountIn)
+        public
+        view
+        returns (uint256 xCitadelAmount_)
+    {
+        uint256 citadelAmount = getAmountOut(_assetAmountIn);
+        xCitadelAmount_ =
+            (citadelAmount * ONE_ETH) /
+            xCitadel.getPricePerFullShare();
     }
 
     /**
@@ -402,7 +401,6 @@ contract Funding is GlobalAccessControlManaged, ReentrancyGuardUpgradeable {
         gacPausable
         onlyRole(CONTRACT_GOVERNANCE_ROLE)
     {
-
         require(_minPrice <= _maxPrice, "minPrice > maxPrice");
         minCitadelPerAsset = _minPrice;
         maxCitadelPerAsset = _maxPrice;
@@ -420,11 +418,12 @@ contract Funding is GlobalAccessControlManaged, ReentrancyGuardUpgradeable {
         external
         gacPausable
         onlyRole(KEEPER_ROLE)
-    {   
-        uint _citadelPerAsset;
+    {
+        uint256 _citadelPerAsset;
         bool _valid;
 
-        (_citadelPerAsset, _valid) = IMedianOracle(citadelPerAssetOracle).getData();
+        (_citadelPerAsset, _valid) = IMedianOracle(citadelPerAssetOracle)
+            .getData();
 
         require(_citadelPerAsset > 0, "price must not be zero");
         require(_valid, "oracle data must be valid");

--- a/src/GlobalAccessControl.sol
+++ b/src/GlobalAccessControl.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.0;
 pragma experimental ABIEncoderV2;
 
-import {IERC20Upgradeable} from "openzeppelin-contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol"; 
+import {IERC20Upgradeable} from "openzeppelin-contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import {SafeERC20Upgradeable} from "openzeppelin-contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
 import {PausableUpgradeable} from "openzeppelin-contracts-upgradeable/security/PausableUpgradeable.sol";
 import {AccessControlEnumerableUpgradeable} from "openzeppelin-contracts-upgradeable/access/AccessControlEnumerableUpgradeable.sol";
@@ -63,7 +63,7 @@ contract GlobalAccessControl is
 
         // Set this for assumptions and clarity
         _setupRole(DEFAULT_ADMIN_ROLE, _initialContractGovernance);
-        
+
         _setupRole(CONTRACT_GOVERNANCE_ROLE, _initialContractGovernance);
 
         // All roles are managed by CONTRACT_GOVERNANCE_ROLE

--- a/src/Importer.sol
+++ b/src/Importer.sol
@@ -4,5 +4,4 @@ pragma solidity ^0.8.4;
 import {ProxyAdmin} from "openzeppelin-contracts/proxy/transparent/ProxyAdmin.sol";
 import {TransparentUpgradeableProxy} from "openzeppelin-contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 
-contract Importer  {
-}
+contract Importer {}

--- a/src/KnightingRound.sol
+++ b/src/KnightingRound.sol
@@ -13,7 +13,10 @@ import "./lib/GlobalAccessControlManaged.sol";
  * @notice Sells citadel at a predetermined price to whitelisted buyers. Citadel tokens are not distributed until the finalize event.
  * TODO: Better revert strings
  */
-contract KnightingRound is GlobalAccessControlManaged, ReentrancyGuardUpgradeable {
+contract KnightingRound is
+    GlobalAccessControlManaged,
+    ReentrancyGuardUpgradeable
+{
     using SafeERC20Upgradeable for ERC20Upgradeable;
 
     bytes32 public constant CONTRACT_GOVERNANCE_ROLE =
@@ -40,7 +43,7 @@ contract KnightingRound is GlobalAccessControlManaged, ReentrancyGuardUpgradeabl
     bool public finalized;
 
     /// CTDL per tokenIn scaled to 10^18
-    /// eg. 1 WBTC = 21 CTDL => 21 x 10^18 
+    /// eg. 1 WBTC = 21 CTDL => 21 x 10^18
     uint256 public tokenOutPerTokenIn;
 
     /// Amounts bought by accounts
@@ -400,7 +403,12 @@ contract KnightingRound is GlobalAccessControlManaged, ReentrancyGuardUpgradeabl
      *      (current contract balance - amount left to be claimed)
      * @param _token The token to sweep
      */
-    function sweep(address _token) external gacPausable nonReentrant onlyRole(TREASURY_OPERATIONS_ROLE) {
+    function sweep(address _token)
+        external
+        gacPausable
+        nonReentrant
+        onlyRole(TREASURY_OPERATIONS_ROLE)
+    {
         uint256 amount = ERC20Upgradeable(_token).balanceOf(address(this));
 
         if (_token == address(tokenOut)) {

--- a/src/KnightingRoundGuestlist.sol
+++ b/src/KnightingRoundGuestlist.sol
@@ -44,7 +44,10 @@ contract KnightingRoundGuestlist is GlobalAccessControlManaged {
      * @param _invited A flag for each guest at the matching index, inviting or
      * uninviting the guest.
      */
-    function setGuests(address[] calldata _guests, bool[] calldata _invited) external onlyRole(TECH_OPERATIONS_ROLE) {
+    function setGuests(address[] calldata _guests, bool[] calldata _invited)
+        external
+        onlyRole(TECH_OPERATIONS_ROLE)
+    {
         _setGuests(_guests, _invited);
     }
 
@@ -53,7 +56,9 @@ contract KnightingRoundGuestlist is GlobalAccessControlManaged {
      * @notice Note that the list is designed to ONLY EXPAND in future instances
      * @notice The admin does retain the ability to ban individual addresses
      */
-    function proveInvitation(address account, bytes32[] calldata merkleProof) public {
+    function proveInvitation(address account, bytes32[] calldata merkleProof)
+        public
+    {
         // Verify Merkle Proof
         require(_verifyInvitationProof(account, merkleProof));
 
@@ -73,7 +78,10 @@ contract KnightingRoundGuestlist is GlobalAccessControlManaged {
      * @notice Note that accounts not included in the root will still be invited if their inviation was previously approved.
      * @notice Setting to 0 removes proof verification versus the root, opening access
      */
-    function setGuestRoot(bytes32 guestRoot_) external onlyRole(TECH_OPERATIONS_ROLE) {
+    function setGuestRoot(bytes32 guestRoot_)
+        external
+        onlyRole(TECH_OPERATIONS_ROLE)
+    {
         guestRoot = guestRoot_;
 
         emit SetGuestRoot(guestRoot);
@@ -84,13 +92,16 @@ contract KnightingRoundGuestlist is GlobalAccessControlManaged {
      * the party.
      * @param _guest The guest's address to check.
      */
-    function authorized(
-        address _guest,
-        bytes32[] calldata _merkleProof
-    ) external view returns (bool) {
+    function authorized(address _guest, bytes32[] calldata _merkleProof)
+        external
+        view
+        returns (bool)
+    {
         // Yes: If the user is on the list or there's no guestRoot set
         // No: If the user is not on the list
-        bool invited = guests[_guest] || _verifyInvitationProof(_guest, _merkleProof) || guestRoot == bytes32(0);
+        bool invited = guests[_guest] ||
+            _verifyInvitationProof(_guest, _merkleProof) ||
+            guestRoot == bytes32(0);
 
         // If the user was previously invited, or proved invitiation via list, verify if the amount to deposit keeps them under the cap
         if (invited) {
@@ -100,7 +111,9 @@ contract KnightingRoundGuestlist is GlobalAccessControlManaged {
         }
     }
 
-    function _setGuests(address[] memory _guests, bool[] memory _invited) internal {
+    function _setGuests(address[] memory _guests, bool[] memory _invited)
+        internal
+    {
         require(_guests.length == _invited.length);
         for (uint256 i = 0; i < _guests.length; i++) {
             if (_guests[i] == address(0)) {
@@ -110,7 +123,10 @@ contract KnightingRoundGuestlist is GlobalAccessControlManaged {
         }
     }
 
-    function _verifyInvitationProof(address account, bytes32[] calldata merkleProof) internal view returns (bool) {
+    function _verifyInvitationProof(
+        address account,
+        bytes32[] calldata merkleProof
+    ) internal view returns (bool) {
         bytes32 node = keccak256(abi.encodePacked(account));
         return MerkleProofUpgradeable.verify(merkleProof, guestRoot, node);
     }

--- a/src/StakedCitadel.sol
+++ b/src/StakedCitadel.sol
@@ -458,10 +458,13 @@ contract StakedCitadel is
             performanceFeeStrategist
         );
 
-        if(governanceRewardsFee != 0) {
-            IERC20Upgradeable(_token).safeTransfer(treasury, governanceRewardsFee);
+        if (governanceRewardsFee != 0) {
+            IERC20Upgradeable(_token).safeTransfer(
+                treasury,
+                governanceRewardsFee
+            );
         }
-        if(strategistRewardsFee != 0) {
+        if (strategistRewardsFee != 0) {
             IERC20Upgradeable(_token).safeTransfer(
                 strategist,
                 strategistRewardsFee
@@ -836,7 +839,7 @@ contract StakedCitadel is
 
         // After you burned the shares, and you have sent the funds, adding here is equivalent to depositing
         // Process withdrawal fee
-        if(_fee > 0) {
+        if (_fee > 0) {
             _mintSharesFor(treasury, _fee, balance() - _fee);
         }
     }

--- a/src/StakedCitadelVester.sol
+++ b/src/StakedCitadelVester.sol
@@ -82,7 +82,11 @@ contract StakedCitadelVester is
      * @param recipient The account to transfer unlocked tokens to.
      * @param amount The amount to transfer. If greater than the claimable amount, the maximum is transferred.
      */
-    function claim(address recipient, uint256 amount) external gacPausable nonReentrant {
+    function claim(address recipient, uint256 amount)
+        external
+        gacPausable
+        nonReentrant
+    {
         require(amount > 0, "StakedCitadelVester: cannot claim 0");
 
         uint256 claimable = claimableBalance(msg.sender);

--- a/src/SupplySchedule.sol
+++ b/src/SupplySchedule.sol
@@ -102,24 +102,34 @@ contract SupplySchedule is GlobalAccessControlManaged, DSTest {
 
         uint256 mintable = 0;
 
-        uint256 startingEpoch = (lastMintTimestamp - cachedGlobalStartTimestamp) /
-            epochLength;
+        uint256 startingEpoch = (lastMintTimestamp -
+            cachedGlobalStartTimestamp) / epochLength;
 
         uint256 endingEpoch = (block.timestamp - cachedGlobalStartTimestamp) /
             epochLength;
 
-        for (uint256 i = startingEpoch; i <= endingEpoch; /** See below ++i */) {
+        for (
+            uint256 i = startingEpoch;
+            i <= endingEpoch; /** See below ++i */
+
+        ) {
             uint256 rate = epochRate[i];
 
-            uint256 epochStartTime = cachedGlobalStartTimestamp + i * epochLength;
-            uint256 epochEndTime = cachedGlobalStartTimestamp + (i + 1) * epochLength;
+            uint256 epochStartTime = cachedGlobalStartTimestamp +
+                i *
+                epochLength;
+            uint256 epochEndTime = cachedGlobalStartTimestamp +
+                (i + 1) *
+                epochLength;
 
             uint256 time = MathUpgradeable.min(block.timestamp, epochEndTime) -
                 MathUpgradeable.max(lastMintTimestamp, epochStartTime);
 
             mintable += rate * time;
 
-            unchecked { ++i; }
+            unchecked {
+                ++i;
+            }
         }
 
         return mintable;

--- a/src/interfaces/badger/IBadgerGuestlist.sol
+++ b/src/interfaces/badger/IBadgerGuestlist.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >= 0.5.0 <= 0.9.0;
+pragma solidity >=0.5.0 <=0.9.0;
 
 interface IBadgerGuestlist {
     function authorized(
         address guest,
-        uint amount,
+        uint256 amount,
         bytes32[] calldata merkleProof
     ) external view returns (bool);
 

--- a/src/interfaces/badger/IBadgerVipGuestlist.sol
+++ b/src/interfaces/badger/IBadgerVipGuestlist.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >= 0.5.0 <= 0.9.0;
+pragma solidity >=0.5.0 <=0.9.0;
 
 interface IBadgerVipGuestlist {
-    function authorized(
-        address guest,
-        bytes32[] calldata merkleProof
-    ) external view returns (bool);
+    function authorized(address guest, bytes32[] calldata merkleProof)
+        external
+        view
+        returns (bool);
 
     function setGuests(address[] calldata _guests, bool[] calldata _invited)
         external;

--- a/src/interfaces/badger/IBadgerWrapperApi.sol
+++ b/src/interfaces/badger/IBadgerWrapperApi.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >= 0.5.0 <= 0.9.0;
+pragma solidity >=0.5.0 <=0.9.0;
 pragma experimental ABIEncoderV2;
 
 import "../erc20/IERC20.sol";
@@ -9,7 +9,10 @@ interface BadgerWrapperAPI is IERC20 {
 
     function pricePerShare() external view returns (uint256);
 
-    function totalWrapperBalance(address account) external view returns (uint256);
+    function totalWrapperBalance(address account)
+        external
+        view
+        returns (uint256);
 
     function totalVaultBalance(address account) external view returns (uint256);
 }

--- a/src/interfaces/badger/IEmptyStrategy.sol
+++ b/src/interfaces/badger/IEmptyStrategy.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >= 0.5.0 <= 0.9.0;
+pragma solidity >=0.5.0 <=0.9.0;
 
 interface IEmptyStrategy {
     // Return value for harvest, tend and balanceOfRewards

--- a/src/interfaces/badger/IStrategy.sol
+++ b/src/interfaces/badger/IStrategy.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >= 0.5.0 <= 0.9.0;
+pragma solidity >=0.5.0 <=0.9.0;
 
 interface IStrategy {
     // Return value for harvest, tend and balanceOfRewards

--- a/src/interfaces/badger/IVault.sol
+++ b/src/interfaces/badger/IVault.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >= 0.5.0 <= 0.9.0;
+pragma solidity >=0.5.0 <=0.9.0;
 
 import {IERC20} from "../erc20/IERC20.sol";
 

--- a/src/interfaces/chainlink/IAggregatorV3Interface.sol
+++ b/src/interfaces/chainlink/IAggregatorV3Interface.sol
@@ -1,54 +1,35 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >= 0.5.0 <= 0.9.0;
+pragma solidity >=0.5.0 <=0.9.0;
 
 interface IAggregatorV3Interface {
+    function decimals() external view returns (uint8);
 
-  function decimals()
-    external
-    view
-    returns (
-      uint8
-    );
+    function description() external view returns (string memory);
 
-  function description()
-    external
-    view
-    returns (
-      string memory
-    );
+    function version() external view returns (uint256);
 
-  function version()
-    external
-    view
-    returns (
-      uint256
-    );
+    // getRoundData and latestRoundData should both raise "No data present"
+    // if they do not have data to report, instead of returning unset values
+    // which could be misinterpreted as actual reported values.
+    function getRoundData(uint80 _roundId)
+        external
+        view
+        returns (
+            uint80 roundId,
+            int256 answer,
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        );
 
-  // getRoundData and latestRoundData should both raise "No data present"
-  // if they do not have data to report, instead of returning unset values
-  // which could be misinterpreted as actual reported values.
-  function getRoundData(
-    uint80 _roundId
-  )
-    external
-    view
-    returns (
-      uint80 roundId,
-      int256 answer,
-      uint256 startedAt,
-      uint256 updatedAt,
-      uint80 answeredInRound
-    );
-
-  function latestRoundData()
-    external
-    view
-    returns (
-      uint80 roundId,
-      int256 answer,
-      uint256 startedAt,
-      uint256 updatedAt,
-      uint80 answeredInRound
-    );
-
+    function latestRoundData()
+        external
+        view
+        returns (
+            uint80 roundId,
+            int256 answer,
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        );
 }

--- a/src/interfaces/citadel/ICitadelToken.sol
+++ b/src/interfaces/citadel/ICitadelToken.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >= 0.5.0 <= 0.9.0;
+pragma solidity >=0.5.0 <=0.9.0;
 
 import {IERC20} from "../erc20/IERC20.sol";
 

--- a/src/interfaces/citadel/IGac.sol
+++ b/src/interfaces/citadel/IGac.sol
@@ -1,6 +1,6 @@
 /// SPDX-License-Identifier: MIT
 
-pragma solidity >= 0.5.0 <= 0.9.0;
+pragma solidity >=0.5.0 <=0.9.0;
 
 interface IGac {
     function paused() external view returns (bool);

--- a/src/interfaces/citadel/IKnightingRound.sol
+++ b/src/interfaces/citadel/IKnightingRound.sol
@@ -4,5 +4,6 @@ pragma solidity >=0.5.0 <=0.9.0;
 
 interface IKnightingRound {
     function boughtAmounts(address account) external view returns (uint256);
+
     function tokenOutPerTokenIn() external view returns (uint256);
 }

--- a/src/interfaces/citadel/IMedianOracle.sol
+++ b/src/interfaces/citadel/IMedianOracle.sol
@@ -3,7 +3,6 @@
 pragma solidity >=0.5.0 <=0.9.0;
 
 interface IMedianOracle {
-
     struct Report {
         uint256 timestamp;
         uint256 payload;
@@ -12,22 +11,38 @@ interface IMedianOracle {
     event ProviderAdded(address provider);
     event ProviderRemoved(address provider);
     event ReportTimestampOutOfRange(address provider);
-    event ProviderReportPushed(address indexed provider, uint256 payload, uint256 timestamp);
+    event ProviderReportPushed(
+        address indexed provider,
+        uint256 payload,
+        uint256 timestamp
+    );
 
-    function reportExpirationTimeSec() external view returns(uint256);
-    function reportDelaySec() external view returns(uint256);
-    function minimumProviders() external view returns(uint256);
+    function reportExpirationTimeSec() external view returns (uint256);
+
+    function reportDelaySec() external view returns (uint256);
+
+    function minimumProviders() external view returns (uint256);
 
     function providers(uint256) external view returns (address);
+
     function providersSize() external view returns (uint256);
-    function providerReports(address, uint256) external view returns (uint256, uint256);
+
+    function providerReports(address, uint256)
+        external
+        view
+        returns (uint256, uint256);
+
     function getData() external view returns (uint256, bool);
 
     function addProvider(address provider) external;
+
     function removeProvider(address provider) external;
+
     function pushReport(uint256 payload) external;
 
     function setReportExpirationTimeSec(uint256) external;
+
     function setReportDelaySec(uint256) external;
+
     function setMinimumProviders(uint256) external;
 }

--- a/src/interfaces/citadel/IStakedCitadelLocker.sol
+++ b/src/interfaces/citadel/IStakedCitadelLocker.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >= 0.5.0 <= 0.9.0;
+pragma solidity >=0.5.0 <=0.9.0;
 
 interface IStakedCitadelLocker {
     function initialize(
@@ -16,25 +16,30 @@ interface IStakedCitadelLocker {
         bool _useBoost
     ) external;
 
+    function notifyRewardAmount(address _rewardsToken, uint256 _reward)
+        external;
 
-    function notifyRewardAmount(address _rewardsToken, uint256 _reward) external;
-    function notifyRewardAmount(address _rewardsToken, uint256 _reward, bytes32 _dataTypeHash) external;
+    function notifyRewardAmount(
+        address _rewardsToken,
+        uint256 _reward,
+        bytes32 _dataTypeHash
+    ) external;
 
     function lock(
         address _account,
         uint256 _amount,
         uint256 _spendRatio
-    ) external ;
+    ) external;
 
     function withdrawExpiredLocksTo(address _withdrawTo) external;
 
     function getReward(address _account) external;
 
-    function rewardPerToken(address _rewardsToken) external returns(uint256);
+    function rewardPerToken(address _rewardsToken) external returns (uint256);
 
-    function lockDuration() external returns(uint256);
+    function lockDuration() external returns (uint256);
 
-    function rewardsDuration() external returns(uint256);
+    function rewardsDuration() external returns (uint256);
 
     function processExpiredLocks(bool _relock) external;
 

--- a/src/interfaces/citadel/ISupplySchedule.sol
+++ b/src/interfaces/citadel/ISupplySchedule.sol
@@ -1,9 +1,14 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >= 0.5.0 <= 0.9.0;
+pragma solidity >=0.5.0 <=0.9.0;
 
 interface ISupplySchedule {
-    function getMintable(uint lastMintTimestamp) external view returns (uint256);
+    function getMintable(uint256 lastMintTimestamp)
+        external
+        view
+        returns (uint256);
+
     function getMintableDebug() external;
+
     function globalStartTimestamp() external view returns (uint256);
 }

--- a/src/interfaces/citadel/IVesting.sol
+++ b/src/interfaces/citadel/IVesting.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >= 0.5.0 <= 0.9.0;
+pragma solidity >=0.5.0 <=0.9.0;
 
 interface IVesting {
     function setupVesting(

--- a/src/interfaces/convex/BoringMath.sol
+++ b/src/interfaces/convex/BoringMath.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >= 0.5.0 <= 0.9.0;
+pragma solidity >=0.5.0 <=0.9.0;
 
 /// @notice A library for performing overflow-/underflow-safe math,
 /// updated with awesomeness from of DappHub (https://github.com/dapphub/ds-math).

--- a/src/interfaces/convex/IRewardStaking.sol
+++ b/src/interfaces/convex/IRewardStaking.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >= 0.5.0 <= 0.9.0;
+pragma solidity >=0.5.0 <=0.9.0;
 
 interface IRewardStaking {
     function stakeFor(address, uint256) external;

--- a/src/interfaces/convex/IStakingProxy.sol
+++ b/src/interfaces/convex/IStakingProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >= 0.5.0 <= 0.9.0;
+pragma solidity >=0.5.0 <=0.9.0;
 
 interface IStakingProxy {
     function getBalance() external view returns (uint256);

--- a/src/interfaces/convex/MathUtil.sol
+++ b/src/interfaces/convex/MathUtil.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >= 0.5.0 <= 0.9.0;
+pragma solidity >=0.5.0 <=0.9.0;
 
 /**
  * @dev Standard math utilities missing in the Solidity language.

--- a/src/interfaces/curve/ICurveCryptoSwap.sol
+++ b/src/interfaces/curve/ICurveCryptoSwap.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >= 0.5.0 <= 0.9.0;
+pragma solidity >=0.5.0 <=0.9.0;
 
 interface ICurveCryptoSwap {
     function price_oracle() external view returns (uint256);

--- a/src/interfaces/erc20/IERC20.sol
+++ b/src/interfaces/erc20/IERC20.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >= 0.5.0 <= 0.9.0;
+pragma solidity >=0.5.0 <=0.9.0;
 
 /**
  * @dev Interface of the ERC20 standard as defined in the EIP.

--- a/src/test/utils/Utils.sol
+++ b/src/test/utils/Utils.sol
@@ -30,7 +30,11 @@ abstract contract Utils {
         return string(buffer);
     }
 
-    function concatenate(string memory a,string memory b) public pure returns (string memory){
-        return string(abi.encodePacked(a,b));
+    function concatenate(string memory a, string memory b)
+        public
+        pure
+        returns (string memory)
+    {
+        return string(abi.encodePacked(a, b));
     }
 }


### PR DESCRIPTION
```diff
-    "prettier:solidity": "./node_modules/.bin/prettier --write src/**/*.sol",
+    "prettier:solidity": "prettier --write 'src/**/*.sol'",
```

Should ideally be merged after any pending PRs