### PR TITLE
Adapted KR tests to return xCTDL instead of CTDL

### DIFF
--- a/src/test/BaseFixture.sol
+++ b/src/test/BaseFixture.sol
@@ -536,9 +536,15 @@ contract BaseFixture is DSTest, Utils, stdCheats {
         uint256 initialSupply = (citadelBought * 1666666666666666667) / 1e18; // Amount bought = 60% of initial supply, therefore total citadel ~= 1.67 amount bought.
 
         citadel.mint(governance, initialSupply);
-        citadel.approve(address(xCitadel), citadelBought + citadelBoughtWithEth);
+        citadel.approve(
+            address(xCitadel),
+            citadelBought + citadelBoughtWithEth
+        );
         xCitadel.depositFor(address(knightingRound), citadelBought);
-        xCitadel.depositFor(address(knightingRoundWithEth), citadelBoughtWithEth);
+        xCitadel.depositFor(
+            address(knightingRoundWithEth),
+            citadelBoughtWithEth
+        );
         uint256 remainingSupply = initialSupply - citadelBought - 1e18; // one coin for seeding xCitadel
 
         citadel.approve(address(xCitadel), 1e18);

--- a/src/test/BaseFixture.sol
+++ b/src/test/BaseFixture.sol
@@ -220,14 +220,14 @@ contract BaseFixture is DSTest, Utils, stdCheats {
         knightingRoundParams = KnightingRoundParams({
             start: block.timestamp + 100,
             duration: 7 days,
-            citadelWbtcPrice: 21e18, // 21 CTDL per wBTC
+            citadelWbtcPrice: 21e18, // 21 xCTDL per wBTC
             tokenInLimit: 100e8 // 100 wBTC
         });
 
         knightingRoundWithEthParams = KnightingRoundParams({
             start: block.timestamp + 100,
             duration: 7 days,
-            citadelWbtcPrice: 21e18, // 21 CTDL per ETH
+            citadelWbtcPrice: 21e18, // 21 xCTDL per ETH
             tokenInLimit: 100e18 // 100 ETH
         });
 
@@ -235,7 +235,7 @@ contract BaseFixture is DSTest, Utils, stdCheats {
 
         knightingRound.initialize(
             address(gac),
-            address(citadel),
+            address(xCitadel),
             address(wbtc),
             knightingRoundParams.start,
             knightingRoundParams.duration,
@@ -247,7 +247,7 @@ contract BaseFixture is DSTest, Utils, stdCheats {
 
         knightingRoundWithEth.initialize(
             address(gac),
-            address(citadel),
+            address(xCitadel),
             address(weth),
             knightingRoundWithEthParams.start,
             knightingRoundWithEthParams.duration,
@@ -449,9 +449,6 @@ contract BaseFixture is DSTest, Utils, stdCheats {
                     accounts_to_track[i]
                 )
             );
-
-            // emit log(wbtc_key);
-            // emit log(citadel_key);
         }
 
         comparator.addCall(
@@ -539,8 +536,9 @@ contract BaseFixture is DSTest, Utils, stdCheats {
         uint256 initialSupply = (citadelBought * 1666666666666666667) / 1e18; // Amount bought = 60% of initial supply, therefore total citadel ~= 1.67 amount bought.
 
         citadel.mint(governance, initialSupply);
-        citadel.transfer(address(knightingRound), citadelBought);
-        citadel.transfer(address(knightingRoundWithEth), citadelBoughtWithEth);
+        citadel.approve(address(xCitadel), citadelBought + citadelBoughtWithEth);
+        xCitadel.depositFor(address(knightingRound), citadelBought);
+        xCitadel.depositFor(address(knightingRoundWithEth), citadelBoughtWithEth);
         uint256 remainingSupply = initialSupply - citadelBought - 1e18; // one coin for seeding xCitadel
 
         citadel.approve(address(xCitadel), 1e18);


### PR DESCRIPTION
This PR closes #149 

- Adapted fixture and KnightingRound tests to use xCTDL as the tokenOut.
- Since it is decided to keep CTDL 1:1 xCTDL during the KRs, minting of assets was performed under this assumption.