### PR TITLE
Add ETH/CTDL and BTC/CTDL chainlink provider

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -8,5 +8,6 @@ remappings = [
     'openzeppelin-contracts/=lib/openzeppelin-contracts/contracts/',
     'forge-std/=lib/forge-std/src/',
 ]
+verbosity = 3
 
 # See more config options https://github.com/gakonst/foundry/tree/master/config

--- a/src/oracles/CtdlAssetChainlinkProvider.sol
+++ b/src/oracles/CtdlAssetChainlinkProvider.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.0;
 import {ChainlinkUtils} from "./ChainlinkUtils.sol";
 import {MedianOracleProvider} from "./MedianOracleProvider.sol";
 import {ICurveCryptoSwap} from "../interfaces/curve/ICurveCryptoSwap.sol";
-import {IMedianOracle} from "../interfaces/citadel/IMedianOracle.sol";
 import {IAggregatorV3Interface} from "../interfaces/chainlink/IAggregatorV3Interface.sol";
 
 contract CtdlAssetChainlinkProvider is ChainlinkUtils, MedianOracleProvider {

--- a/src/oracles/CtdlBtcChainlinkProvider.sol
+++ b/src/oracles/CtdlBtcChainlinkProvider.sol
@@ -17,12 +17,6 @@ contract CtdlBtcChainlinkProvider is ChainlinkUtils, MedianOracleProvider {
     IAggregatorV3Interface public immutable wbtcBtcPriceFeed;
 
     /// =====================
-    /// ===== Constants =====
-    /// =====================
-
-    uint256 constant PRECISION = 10**18;
-
-    /// =====================
     /// ===== Functions =====
     /// =====================
 

--- a/src/oracles/CtdlBtcChainlinkProvider.sol
+++ b/src/oracles/CtdlBtcChainlinkProvider.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {ChainlinkUtils} from "./ChainlinkUtils.sol";
+import {MedianOracleProvider} from "./MedianOracleProvider.sol";
+import {ICurveCryptoSwap} from "../interfaces/curve/ICurveCryptoSwap.sol";
+import {IMedianOracle} from "../interfaces/citadel/IMedianOracle.sol";
+import {IAggregatorV3Interface} from "../interfaces/chainlink/IAggregatorV3Interface.sol";
+
+contract CtdlBtcChainlinkProvider is ChainlinkUtils, MedianOracleProvider {
+    /// =================
+    /// ===== State =====
+    /// =================
+
+    ICurveCryptoSwap public immutable ctdlWbtcCurvePool;
+
+    // Price feeds
+    IAggregatorV3Interface public immutable wbtcBtcPriceFeed;
+
+    /// =====================
+    /// ===== Constants =====
+    /// =====================
+
+    uint256 constant PRECISION = 10**18;
+
+    /// =====================
+    /// ===== Functions =====
+    /// =====================
+
+    constructor(
+        address _medianOracle,
+        address _ctdlWbtcCurvePool,
+        address _wbtcBtcPriceFeed
+    ) MedianOracleProvider(_medianOracle) {
+        ctdlWbtcCurvePool = ICurveCryptoSwap(_ctdlWbtcCurvePool);
+
+        wbtcBtcPriceFeed = IAggregatorV3Interface(_wbtcBtcPriceFeed);
+    }
+
+    /// =======================
+    /// ===== Public view =====
+    /// =======================
+
+    function latestAnswer()
+        public
+        view
+        override
+        returns (uint256 btcPriceInCtdl_)
+    {
+        uint256 wbtcPriceInBtc = safeLatestAnswer(wbtcBtcPriceFeed);
+
+        // 18 decimals
+        uint256 wbtcPriceInCtdl = ctdlWbtcCurvePool.price_oracle();
+
+        btcPriceInCtdl_ =
+            (wbtcPriceInCtdl * 10**wbtcBtcPriceFeed.decimals()) /
+            wbtcPriceInBtc;
+    }
+}

--- a/src/oracles/CtdlBtcChainlinkProvider.sol
+++ b/src/oracles/CtdlBtcChainlinkProvider.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.0;
 import {ChainlinkUtils} from "./ChainlinkUtils.sol";
 import {MedianOracleProvider} from "./MedianOracleProvider.sol";
 import {ICurveCryptoSwap} from "../interfaces/curve/ICurveCryptoSwap.sol";
-import {IMedianOracle} from "../interfaces/citadel/IMedianOracle.sol";
 import {IAggregatorV3Interface} from "../interfaces/chainlink/IAggregatorV3Interface.sol";
 
 contract CtdlBtcChainlinkProvider is ChainlinkUtils, MedianOracleProvider {

--- a/src/oracles/CtdlEthChainlinkProvider.sol
+++ b/src/oracles/CtdlEthChainlinkProvider.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.0;
 import {ChainlinkUtils} from "./ChainlinkUtils.sol";
 import {MedianOracleProvider} from "./MedianOracleProvider.sol";
 import {ICurveCryptoSwap} from "../interfaces/curve/ICurveCryptoSwap.sol";
-import {IMedianOracle} from "../interfaces/citadel/IMedianOracle.sol";
 import {IAggregatorV3Interface} from "../interfaces/chainlink/IAggregatorV3Interface.sol";
 
 contract CtdlEthChainlinkProvider is ChainlinkUtils, MedianOracleProvider {

--- a/src/oracles/CtdlWbtcCurveV2Provider.sol
+++ b/src/oracles/CtdlWbtcCurveV2Provider.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.0;
 
 import {MedianOracleProvider} from "./MedianOracleProvider.sol";
 import {ICurveCryptoSwap} from "../interfaces/curve/ICurveCryptoSwap.sol";
-import {IMedianOracle} from "../interfaces/citadel/IMedianOracle.sol";
 
 contract CtdlWbtcCurveV2Provider is MedianOracleProvider {
     /// =================

--- a/src/oracles/CtdlWibbtcLpVaultProvider.sol
+++ b/src/oracles/CtdlWibbtcLpVaultProvider.sol
@@ -5,7 +5,6 @@ import {ChainlinkUtils} from "./ChainlinkUtils.sol";
 import {MedianOracleProvider} from "./MedianOracleProvider.sol";
 import {ICurvePool} from "../interfaces/curve/ICurvePool.sol";
 import {ICurveCryptoSwap} from "../interfaces/curve/ICurveCryptoSwap.sol";
-import {IMedianOracle} from "../interfaces/citadel/IMedianOracle.sol";
 import {IAggregatorV3Interface} from "../interfaces/chainlink/IAggregatorV3Interface.sol";
 import {IVault} from "../interfaces/badger/IVault.sol";
 

--- a/src/oracles/CtdlWibbtcLpVaultProvider.sol
+++ b/src/oracles/CtdlWibbtcLpVaultProvider.sol
@@ -58,7 +58,7 @@ contract CtdlWibbtcLpVaultProvider is ChainlinkUtils, MedianOracleProvider {
         // 8 decimals
         uint256 wbtcPriceInBtc = safeLatestAnswer(wbtcBtcPriceFeed);
         // 18 decimals
-        uint256 wibbtcLpVaultPriceInWbtc = (wibbtcLpVault
+        uint256 wibbtcLpVaultPriceInBtc = (wibbtcLpVault
             .getPricePerFullShare() * wibbtcCrvPool.get_virtual_price()) /
             PRECISION;
 
@@ -67,7 +67,7 @@ contract CtdlWibbtcLpVaultProvider is ChainlinkUtils, MedianOracleProvider {
 
         // 18 decimals
         wibbtcLpVaultPriceInCtdl_ =
-            (wibbtcLpVaultPriceInWbtc *
+            (wibbtcLpVaultPriceInBtc *
                 wbtcPriceInCtdl *
                 10**wbtcBtcPriceFeed.decimals()) /
             wbtcPriceInBtc /


### PR DESCRIPTION
- Uses BTC-ETH, WBTC-BTC and CTDL curve v2 pool's `price_oracle` to get ETH-CTDL price feed
- Uses BTC-WBTC and CTDL curve v2 pool's `price_oracle` to get BTC-CTDL price feed

Addresses #140