### PR TITLE
Addition of PROXYADMIN_OWNER_ROLE

### DIFF
--- a/src/GACProxyAdmin.sol
+++ b/src/GACProxyAdmin.sol
@@ -11,8 +11,8 @@ import "./lib/GlobalAccessControlManaged.sol";
  * explanation of why you would want to use this see the documentation for {TransparentUpgradeableProxy}.
  */
 contract GACProxyAdmin is GlobalAccessControlManaged {
-    bytes32 public constant CONTRACT_GOVERNANCE_ROLE =
-        keccak256("CONTRACT_GOVERNANCE_ROLE");
+    bytes32 public constant PROXYADMIN_OWNER_ROLE =
+        keccak256("PROXYADMIN_OWNER_ROLE");
 
     /**
      * @dev Sets the address of the initial implementation, and the deployer account as the owner who can upgrade the
@@ -76,7 +76,7 @@ contract GACProxyAdmin is GlobalAccessControlManaged {
     function changeProxyAdmin(
         TransparentUpgradeableProxy proxy,
         address newAdmin
-    ) public virtual onlyRole(CONTRACT_GOVERNANCE_ROLE) {
+    ) public virtual onlyRole(PROXYADMIN_OWNER_ROLE) {
         proxy.changeAdmin(newAdmin);
     }
 
@@ -90,7 +90,7 @@ contract GACProxyAdmin is GlobalAccessControlManaged {
     function upgrade(TransparentUpgradeableProxy proxy, address implementation)
         public
         virtual
-        onlyRole(CONTRACT_GOVERNANCE_ROLE)
+        onlyRole(PROXYADMIN_OWNER_ROLE)
     {
         proxy.upgradeTo(implementation);
     }
@@ -107,7 +107,7 @@ contract GACProxyAdmin is GlobalAccessControlManaged {
         TransparentUpgradeableProxy proxy,
         address implementation,
         bytes memory data
-    ) public payable virtual onlyRole(CONTRACT_GOVERNANCE_ROLE) {
+    ) public payable virtual onlyRole(PROXYADMIN_OWNER_ROLE) {
         proxy.upgradeToAndCall{value: msg.value}(implementation, data);
     }
 }

--- a/src/GlobalAccessControl.sol
+++ b/src/GlobalAccessControl.sol
@@ -46,6 +46,9 @@ contract GlobalAccessControl is
     bytes32 public constant CITADEL_MINTER_ROLE =
         keccak256("CITADEL_MINTER_ROLE");
 
+    bytes32 public constant PROXYADMIN_OWNER_ROLE =
+        keccak256("PROXYADMIN_OWNER_ROLE");
+
     /// =======================
     /// ===== Initializer =====
     /// =======================
@@ -78,6 +81,7 @@ contract GlobalAccessControl is
         _setRoleAdmin(UNPAUSER_ROLE, CONTRACT_GOVERNANCE_ROLE);
         _setRoleAdmin(BLOCKLIST_MANAGER_ROLE, CONTRACT_GOVERNANCE_ROLE);
         _setRoleAdmin(CITADEL_MINTER_ROLE, CONTRACT_GOVERNANCE_ROLE);
+        _setRoleAdmin(PROXYADMIN_OWNER_ROLE, CONTRACT_GOVERNANCE_ROLE);
 
         // Add default admin role here to avoid governance mistakes
         _setRoleAdmin(DEFAULT_ADMIN_ROLE, CONTRACT_GOVERNANCE_ROLE);

--- a/src/KnightingRoundRegistry.sol
+++ b/src/KnightingRoundRegistry.sol
@@ -16,9 +16,6 @@ contract KnightingRoundRegistry is Initializable {
     // ===== Libraries  ====
     using EnumerableSet for EnumerableSet.AddressSet;
 
-    bytes32 public constant CONTRACT_globalAccessControl_ROLE =
-        keccak256("CONTRACT_globalAccessControl_ROLE");
-
     GACProxyAdmin public gacProxyAdmin;
 
     address public globalAccessControl;

--- a/src/KnightingRoundRegistry.sol
+++ b/src/KnightingRoundRegistry.sol
@@ -16,12 +16,12 @@ contract KnightingRoundRegistry is Initializable {
     // ===== Libraries  ====
     using EnumerableSet for EnumerableSet.AddressSet;
 
-    bytes32 public constant CONTRACT_GOVERNANCE_ROLE =
-        keccak256("CONTRACT_GOVERNANCE_ROLE");
+    bytes32 public constant CONTRACT_globalAccessControl_ROLE =
+        keccak256("CONTRACT_globalAccessControl_ROLE");
 
     GACProxyAdmin public gacProxyAdmin;
 
-    address public governance;
+    address public globalAccessControl;
     address public tokenOut;
     address public saleRecipient;
     address public guestlist;
@@ -60,7 +60,7 @@ contract KnightingRoundRegistry is Initializable {
 
     /// initialize
     function initialize(
-        address _governance,
+        address _globalAccessControl,
         uint256 _roundStart,
         uint256 _roundDuration,
         address _tokenOut,
@@ -69,7 +69,7 @@ contract KnightingRoundRegistry is Initializable {
         InitParam calldata _wethParams,
         InitParam[] calldata _roundParams
     ) public initializer {
-        governance = _governance;
+        globalAccessControl = _globalAccessControl;
         roundStart = _roundStart;
         roundDuration = _roundDuration;
 
@@ -78,7 +78,7 @@ contract KnightingRoundRegistry is Initializable {
         guestlist = _guestlist;
 
         gacProxyAdmin = new GACProxyAdmin();
-        gacProxyAdmin.initialize(_governance);
+        gacProxyAdmin.initialize(_globalAccessControl);
 
         knightingRoundImplementation = address(new KnightingRound());
         knightingRoundWithEthImplementation = address(
@@ -100,7 +100,7 @@ contract KnightingRoundRegistry is Initializable {
                 address(gacProxyAdmin),
                 abi.encodeWithSelector(
                     KnightingRound(address(0)).initialize.selector,
-                    governance,
+                    globalAccessControl,
                     tokenOut,
                     _roundParams._tokenIn,
                     roundStart,
@@ -120,7 +120,7 @@ contract KnightingRoundRegistry is Initializable {
                 address(gacProxyAdmin),
                 abi.encodeWithSelector(
                     KnightingRoundWithEth(address(0)).initialize.selector,
-                    governance,
+                    globalAccessControl,
                     tokenOut,
                     _roundParams._tokenIn,
                     roundStart,

--- a/src/test/BaseFixture.sol
+++ b/src/test/BaseFixture.sol
@@ -59,6 +59,9 @@ contract BaseFixture is DSTest, Utils, stdCheats {
     bytes32 public constant CITADEL_MINTER_ROLE =
         keccak256("CITADEL_MINTER_ROLE");
 
+    bytes32 public constant PROXYADMIN_OWNER_ROLE =
+        keccak256("PROXYADMIN_OWNER_ROLE");
+
     uint256 public constant ONE = 1 ether;
 
     // ==================
@@ -341,6 +344,8 @@ contract BaseFixture is DSTest, Utils, stdCheats {
 
         gac.grantRole(CITADEL_MINTER_ROLE, address(citadelMinter));
         gac.grantRole(CITADEL_MINTER_ROLE, governance); // To handle initial supply, remove atomically.
+
+        gac.grantRole(PROXYADMIN_OWNER_ROLE, governance);
 
         gac.grantRole(PAUSER_ROLE, guardian);
         gac.grantRole(UNPAUSER_ROLE, techOps);

--- a/src/test/GACProxyAdmin.t.sol
+++ b/src/test/GACProxyAdmin.t.sol
@@ -14,7 +14,7 @@ contract GACProxyAdminTest is BaseFixture {
         BaseFixture.setUp();
     }
 
-    function test() public {
+    function testGacProxyAdmin() public {
         vm.startPrank(governance);
 
         GACProxyAdmin gacProxyAdmin = new GACProxyAdmin();

--- a/src/test/KnightingRoundRegistry.t.sol
+++ b/src/test/KnightingRoundRegistry.t.sol
@@ -20,7 +20,7 @@ contract KnightingRoundRegistryTest is BaseFixture {
 
         knightinRoundRegistry = new KnightingRoundRegistry();
 
-        assertEq(address(0), knightinRoundRegistry.governance());
+        assertEq(address(0), knightinRoundRegistry.globalAccessControl());
         assertEq(address(0), knightinRoundRegistry.tokenOut());
         assertEq(address(0), knightinRoundRegistry.saleRecipient());
         assertEq(address(0), knightinRoundRegistry.guestlist());


### PR DESCRIPTION
This PR closes issue #182 

- Introduces the new `PROXYADMIN_OWNER_ROLE` 
- Adapts access control of GACProxyAdmin to be controlled by this role
- Test adapted accordingly

Additionally, the `governance` variable name, of the KnightingRounds Registry, was changed to `globalAccessControl` as it is meant to point to the GAC.