### PR TITLE
allow to set minting start to current timestamp

### DIFF
--- a/src/SupplySchedule.sol
+++ b/src/SupplySchedule.sol
@@ -139,11 +139,23 @@ contract SupplySchedule is GlobalAccessControlManaged, DSTest {
     /// ===== Governance actions =====
     /// ==============================
 
+    function setMintingStartNow()
+        external
+        onlyRole(CONTRACT_GOVERNANCE_ROLE)
+        gacPausable
+    {
+        _setMintingStart(block.timestamp);
+    }
+
     function setMintingStart(uint256 _globalStartTimestamp)
         external
         onlyRole(CONTRACT_GOVERNANCE_ROLE)
         gacPausable
     {
+        _setMintingStart(_globalStartTimestamp);
+    }
+
+    function _setMintingStart(uint256 _globalStartTimestamp) internal {
         require(
             globalStartTimestamp == 0,
             "SupplySchedule: minting already started"

--- a/src/test/AtomicLaunchTest.t.sol
+++ b/src/test/AtomicLaunchTest.t.sol
@@ -508,7 +508,7 @@ contract AtomicLaunchTest is BaseFixture {
             536986000000000000000000 / schedule_launch.epochLength()
         );
         // Set minting start
-        schedule_launch.setMintingStart(block.timestamp);
+        schedule_launch.setMintingStartNow();
 
         vm.stopPrank();
 

--- a/src/test/GlobalAccessControl.t.sol
+++ b/src/test/GlobalAccessControl.t.sol
@@ -319,6 +319,9 @@ contract GlobalAccessControlTest is BaseFixture {
         schedule.setMintingStart(block.timestamp + 1000);
 
         vm.expectRevert(bytes("local-paused"));
+        schedule.setMintingStartNow();
+
+        vm.expectRevert(bytes("local-paused"));
         schedule.setEpochRate(8, 10);
 
         vm.stopPrank();
@@ -328,6 +331,9 @@ contract GlobalAccessControlTest is BaseFixture {
         vm.startPrank(governance);
         vm.expectRevert(bytes("global-paused"));
         schedule.setMintingStart(block.timestamp + 1000);
+
+        vm.expectRevert(bytes("global-paused"));
+        schedule.setMintingStartNow();
 
         vm.expectRevert(bytes("global-paused"));
         schedule.setEpochRate(8, 10);
@@ -420,6 +426,11 @@ contract GlobalAccessControlTest is BaseFixture {
         schedule.setMintingStart(1000);
         vm.prank(governance);
         schedule.setMintingStart(block.timestamp);
+
+        vm.expectRevert("GAC: invalid-caller-role");
+        schedule.setMintingStartNow();
+        // Not attempting a positive test because minting is already started
+        // above - The feature is tested on integration already.
 
         vm.expectRevert("GAC: invalid-caller-role");
         citadelMinter.initializeLastMintTimestamp();

--- a/src/test/MintAndDistribute.t.sol
+++ b/src/test/MintAndDistribute.t.sol
@@ -61,7 +61,7 @@ contract MintAndDistributeTest is BaseFixture {
 
         // policy ops should not be able to start minting schedule
         vm.expectRevert("GAC: invalid-caller-role");
-        schedule.setMintingStart(block.timestamp);
+        schedule.setMintingStartNow();
         assertTrue(schedule.globalStartTimestamp() == 0);
 
         vm.stopPrank();
@@ -71,7 +71,7 @@ contract MintAndDistributeTest is BaseFixture {
         vm.expectRevert("CitadelMinter: supply schedule start not initialized");
         citadelMinter.initializeLastMintTimestamp();
 
-        schedule.setMintingStart(block.timestamp);
+        schedule.setMintingStartNow();
 
         citadelMinter.initializeLastMintTimestamp();
         assertTrue(schedule.globalStartTimestamp() == block.timestamp);


### PR DESCRIPTION
Issue: The Atomic Launch, when run from a multisig, will be uploaded at a different timestamp than it is executed. In order for all actions to launch when the TX is executed, the global minting start timestamp must be set to that time.

Introduce a function variant, `setMintingStartNow()`, to facilitate this while remaining backwards compatible with previous functionality and tests