### PR TITLE
initializable oracles

### DIFF
--- a/src/oracles/CtdlAssetChainlinkProvider.sol
+++ b/src/oracles/CtdlAssetChainlinkProvider.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+import {Initializable} from "openzeppelin-contracts-upgradeable/proxy/utils/Initializable.sol";
 import {MathUpgradeable} from "openzeppelin-contracts-upgradeable/utils/math/MathUpgradeable.sol";
 
 import {ChainlinkUtils} from "./ChainlinkUtils.sol";
@@ -8,17 +9,17 @@ import {MedianOracleProvider} from "./MedianOracleProvider.sol";
 import {ICurveCryptoSwap} from "../interfaces/curve/ICurveCryptoSwap.sol";
 import {IAggregatorV3Interface} from "../interfaces/chainlink/IAggregatorV3Interface.sol";
 
-contract CtdlAssetChainlinkProvider is ChainlinkUtils, MedianOracleProvider {
+contract CtdlAssetChainlinkProvider is Initializable, ChainlinkUtils, MedianOracleProvider {
     /// =================
     /// ===== State =====
     /// =================
 
-    ICurveCryptoSwap public immutable ctdlWbtcCurvePool;
+    ICurveCryptoSwap public ctdlWbtcCurvePool;
 
     // Price feeds
-    IAggregatorV3Interface public immutable wbtcBtcPriceFeed;
-    IAggregatorV3Interface public immutable btcBasePriceFeed;
-    IAggregatorV3Interface public immutable assetBasePriceFeed;
+    IAggregatorV3Interface public wbtcBtcPriceFeed;
+    IAggregatorV3Interface public btcBasePriceFeed;
+    IAggregatorV3Interface public assetBasePriceFeed;
 
     /// =====================
     /// ===== Constants =====
@@ -30,12 +31,12 @@ contract CtdlAssetChainlinkProvider is ChainlinkUtils, MedianOracleProvider {
     /// ===== Functions =====
     /// =====================
 
-    constructor(
+    function initialize(
         address _ctdlWbtcCurvePool,
         address _wbtcBtcPriceFeed,
         address _btcBasePriceFeed,
         address _assetBasePriceFeed
-    ) {
+    ) public initializer {
         ctdlWbtcCurvePool = ICurveCryptoSwap(_ctdlWbtcCurvePool);
 
         wbtcBtcPriceFeed = IAggregatorV3Interface(_wbtcBtcPriceFeed);

--- a/src/oracles/CtdlBtcChainlinkProvider.sol
+++ b/src/oracles/CtdlBtcChainlinkProvider.sol
@@ -1,26 +1,27 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+import {Initializable} from "openzeppelin-contracts-upgradeable/proxy/utils/Initializable.sol";
 import {ChainlinkUtils} from "./ChainlinkUtils.sol";
 import {MedianOracleProvider} from "./MedianOracleProvider.sol";
 import {ICurveCryptoSwap} from "../interfaces/curve/ICurveCryptoSwap.sol";
 import {IAggregatorV3Interface} from "../interfaces/chainlink/IAggregatorV3Interface.sol";
 
-contract CtdlBtcChainlinkProvider is ChainlinkUtils, MedianOracleProvider {
+contract CtdlBtcChainlinkProvider is Initializable, ChainlinkUtils, MedianOracleProvider {
     /// =================
     /// ===== State =====
     /// =================
 
-    ICurveCryptoSwap public immutable ctdlWbtcCurvePool;
+    ICurveCryptoSwap public ctdlWbtcCurvePool;
 
     // Price feeds
-    IAggregatorV3Interface public immutable wbtcBtcPriceFeed;
+    IAggregatorV3Interface public wbtcBtcPriceFeed;
 
     /// =====================
-    /// ===== Functions =====
+    /// ===== Functions =====s
     /// =====================
 
-    constructor(address _ctdlWbtcCurvePool, address _wbtcBtcPriceFeed) {
+    function initialize(address _ctdlWbtcCurvePool, address _wbtcBtcPriceFeed) public initializer {
         ctdlWbtcCurvePool = ICurveCryptoSwap(_ctdlWbtcCurvePool);
 
         wbtcBtcPriceFeed = IAggregatorV3Interface(_wbtcBtcPriceFeed);

--- a/src/oracles/CtdlEthChainlinkProvider.sol
+++ b/src/oracles/CtdlEthChainlinkProvider.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+import {Initializable} from "openzeppelin-contracts-upgradeable/proxy/utils/Initializable.sol";
 import {MathUpgradeable} from "openzeppelin-contracts-upgradeable/utils/math/MathUpgradeable.sol";
 
 import {ChainlinkUtils} from "./ChainlinkUtils.sol";
@@ -8,16 +9,16 @@ import {MedianOracleProvider} from "./MedianOracleProvider.sol";
 import {ICurveCryptoSwap} from "../interfaces/curve/ICurveCryptoSwap.sol";
 import {IAggregatorV3Interface} from "../interfaces/chainlink/IAggregatorV3Interface.sol";
 
-contract CtdlEthChainlinkProvider is ChainlinkUtils, MedianOracleProvider {
+contract CtdlEthChainlinkProvider is Initializable, ChainlinkUtils, MedianOracleProvider {
     /// =================
     /// ===== State =====
     /// =================
 
-    ICurveCryptoSwap public immutable ctdlWbtcCurvePool;
+    ICurveCryptoSwap public ctdlWbtcCurvePool;
 
     // Price feeds
-    IAggregatorV3Interface public immutable wbtcBtcPriceFeed;
-    IAggregatorV3Interface public immutable btcEthPriceFeed;
+    IAggregatorV3Interface public wbtcBtcPriceFeed;
+    IAggregatorV3Interface public btcEthPriceFeed;
 
     /// =====================
     /// ===== Constants =====
@@ -29,11 +30,11 @@ contract CtdlEthChainlinkProvider is ChainlinkUtils, MedianOracleProvider {
     /// ===== Functions =====
     /// =====================
 
-    constructor(
+    function initialize(
         address _ctdlWbtcCurvePool,
         address _wbtcBtcPriceFeed,
         address _btcEthPriceFeed
-    ) {
+    ) public initializer {
         ctdlWbtcCurvePool = ICurveCryptoSwap(_ctdlWbtcCurvePool);
 
         wbtcBtcPriceFeed = IAggregatorV3Interface(_wbtcBtcPriceFeed);

--- a/src/oracles/CtdlWbtcCurveV2Provider.sol
+++ b/src/oracles/CtdlWbtcCurveV2Provider.sol
@@ -1,21 +1,22 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+import {Initializable} from "openzeppelin-contracts-upgradeable/proxy/utils/Initializable.sol";
 import {MedianOracleProvider} from "./MedianOracleProvider.sol";
 import {ICurveCryptoSwap} from "../interfaces/curve/ICurveCryptoSwap.sol";
 
-contract CtdlWbtcCurveV2Provider is MedianOracleProvider {
+contract CtdlWbtcCurveV2Provider is Initializable, MedianOracleProvider {
     /// =================
     /// ===== State =====
     /// =================
 
-    ICurveCryptoSwap public immutable curvePool;
+    ICurveCryptoSwap public curvePool;
 
     /// =====================
     /// ===== Functions =====
     /// =====================
 
-    constructor(address _curvePool) {
+    function initialize(address _curvePool) public initializer {
         curvePool = ICurveCryptoSwap(_curvePool);
     }
 

--- a/src/oracles/CtdlWibbtcLpVaultProvider.sol
+++ b/src/oracles/CtdlWibbtcLpVaultProvider.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+import {Initializable} from "openzeppelin-contracts-upgradeable/proxy/utils/Initializable.sol";
 import {ChainlinkUtils} from "./ChainlinkUtils.sol";
 import {MedianOracleProvider} from "./MedianOracleProvider.sol";
 import {ICurvePool} from "../interfaces/curve/ICurvePool.sol";
@@ -8,18 +9,18 @@ import {ICurveCryptoSwap} from "../interfaces/curve/ICurveCryptoSwap.sol";
 import {IAggregatorV3Interface} from "../interfaces/chainlink/IAggregatorV3Interface.sol";
 import {IVault} from "../interfaces/badger/IVault.sol";
 
-contract CtdlWibbtcLpVaultProvider is ChainlinkUtils, MedianOracleProvider {
+contract CtdlWibbtcLpVaultProvider is Initializable, ChainlinkUtils, MedianOracleProvider {
     /// =================
     /// ===== State =====
     /// =================
 
-    ICurveCryptoSwap public immutable ctdlWbtcCurvePool;
+    ICurveCryptoSwap public ctdlWbtcCurvePool;
 
-    IVault public immutable wibbtcLpVault;
-    ICurvePool public immutable wibbtcCrvPool;
+    IVault public wibbtcLpVault;
+    ICurvePool public wibbtcCrvPool;
 
     // Price feeds
-    IAggregatorV3Interface public immutable wbtcBtcPriceFeed;
+    IAggregatorV3Interface public wbtcBtcPriceFeed;
 
     /// =====================
     /// ===== Constants =====
@@ -31,11 +32,11 @@ contract CtdlWibbtcLpVaultProvider is ChainlinkUtils, MedianOracleProvider {
     /// ===== Functions =====
     /// =====================
 
-    constructor(
+    function initialize(
         address _ctdlWbtcCurvePool,
         address _wbtcBtcPriceFeed,
         address _wibbtcLpVault
-    ) {
+    ) public initializer {
         ctdlWbtcCurvePool = ICurveCryptoSwap(_ctdlWbtcCurvePool);
         wbtcBtcPriceFeed = IAggregatorV3Interface(_wbtcBtcPriceFeed);
 

--- a/src/test/FundingOracles.t.sol
+++ b/src/test/FundingOracles.t.sol
@@ -73,15 +73,19 @@ contract FundingOraclesTest is BaseFixture {
     function setUp() public override {
         BaseFixture.setUp();
 
-        ctdlWbtcProvider = new CtdlWbtcCurveV2Provider(CTDL_WBTC_CURVE_POOL);
+        ctdlWbtcProvider = new CtdlWbtcCurveV2Provider();
+        ctdlWbtcProvider.initialize(CTDL_WBTC_CURVE_POOL);
 
-        ctdlCvxProvider1 = new CtdlAssetChainlinkProvider(
+        ctdlCvxProvider1 = new CtdlAssetChainlinkProvider();
+        ctdlCvxProvider1.initialize(
             CTDL_WBTC_CURVE_POOL,
             WBTC_BTC_PRICE_FEED,
             BTC_ETH_PRICE_FEED,
             CVX_ETH_PRICE_FEED
         );
-        ctdlCvxProvider2 = new CtdlAssetChainlinkProvider(
+
+        ctdlCvxProvider2 = new CtdlAssetChainlinkProvider();
+        ctdlCvxProvider2.initialize(
             CTDL_WBTC_CURVE_POOL,
             WBTC_BTC_PRICE_FEED,
             BTC_USD_PRICE_FEED,
@@ -94,37 +98,37 @@ contract FundingOraclesTest is BaseFixture {
     }
 
     function testDeployAllOracleProviders() public {
-        CtdlWbtcCurveV2Provider ctdlWbtcProviderLoc = new CtdlWbtcCurveV2Provider(
-                CTDL_WBTC_CURVE_POOL
-            );
+        CtdlWbtcCurveV2Provider ctdlWbtcProviderLoc = new CtdlWbtcCurveV2Provider();
+        ctdlWbtcProviderLoc.initialize(CTDL_WBTC_CURVE_POOL);
         _checkedLatestData(address(ctdlWbtcProviderLoc));
 
-        CtdlBtcChainlinkProvider ctdlBtcProvider = new CtdlBtcChainlinkProvider(
-            CTDL_WBTC_CURVE_POOL,
-            WBTC_BTC_PRICE_FEED
-        );
+        CtdlBtcChainlinkProvider ctdlBtcProvider = new CtdlBtcChainlinkProvider();
+        ctdlBtcProvider.initialize(CTDL_WBTC_CURVE_POOL, WBTC_BTC_PRICE_FEED);
         _checkedLatestData(address(ctdlBtcProvider));
 
-        CtdlWibbtcLpVaultProvider ctdlWibbtcProvider = new CtdlWibbtcLpVaultProvider(
-                CTDL_WBTC_CURVE_POOL,
-                WBTC_BTC_PRICE_FEED,
-                WIBBTC_LP_VAULT
-            );
+        CtdlWibbtcLpVaultProvider ctdlWibbtcProvider = new CtdlWibbtcLpVaultProvider();
+        ctdlWibbtcProvider.initialize(
+            CTDL_WBTC_CURVE_POOL,
+            WBTC_BTC_PRICE_FEED,
+            WIBBTC_LP_VAULT
+        );
         _checkedLatestData(address(ctdlWibbtcProvider));
 
-        CtdlEthChainlinkProvider ctdlEthProvider1 = new CtdlEthChainlinkProvider(
-                CTDL_WBTC_CURVE_POOL,
-                WBTC_BTC_PRICE_FEED,
-                BTC_ETH_PRICE_FEED
-            );
+        CtdlEthChainlinkProvider ctdlEthProvider1 = new CtdlEthChainlinkProvider();
+        ctdlEthProvider1.initialize(
+            CTDL_WBTC_CURVE_POOL,
+            WBTC_BTC_PRICE_FEED,
+            BTC_ETH_PRICE_FEED
+        );
         _checkedLatestData(address(ctdlEthProvider1));
 
-        CtdlAssetChainlinkProvider ctdlEthProvider2 = new CtdlAssetChainlinkProvider(
-                CTDL_WBTC_CURVE_POOL,
-                WBTC_BTC_PRICE_FEED,
-                BTC_USD_PRICE_FEED,
-                ETH_USD_PRICE_FEED
-            );
+        CtdlAssetChainlinkProvider ctdlEthProvider2 = new CtdlAssetChainlinkProvider();
+        ctdlEthProvider2.initialize(
+            CTDL_WBTC_CURVE_POOL,
+            WBTC_BTC_PRICE_FEED,
+            BTC_USD_PRICE_FEED,
+            ETH_USD_PRICE_FEED
+        );
         _checkedLatestData(address(ctdlEthProvider2));
 
         address[4] memory assetEthFeeds = [
@@ -141,19 +145,22 @@ contract FundingOraclesTest is BaseFixture {
         ];
 
         for (uint256 i; i < 4; ++i) {
-            CtdlAssetChainlinkProvider ctdlAssetProvider1 = new CtdlAssetChainlinkProvider(
-                    CTDL_WBTC_CURVE_POOL,
-                    WBTC_BTC_PRICE_FEED,
-                    BTC_ETH_PRICE_FEED,
-                    assetUsdFeeds[i]
-                );
+            CtdlAssetChainlinkProvider ctdlAssetProvider1 = new CtdlAssetChainlinkProvider();
+            ctdlAssetProvider1.initialize(
+                CTDL_WBTC_CURVE_POOL,
+                WBTC_BTC_PRICE_FEED,
+                BTC_ETH_PRICE_FEED,
+                assetUsdFeeds[i]
+            );
             _checkedLatestData(address(ctdlAssetProvider1));
-            CtdlAssetChainlinkProvider ctdlAssetProvider2 = new CtdlAssetChainlinkProvider(
-                    CTDL_WBTC_CURVE_POOL,
-                    WBTC_BTC_PRICE_FEED,
-                    BTC_USD_PRICE_FEED,
-                    assetEthFeeds[i]
-                );
+
+            CtdlAssetChainlinkProvider ctdlAssetProvider2 = new CtdlAssetChainlinkProvider();
+            ctdlAssetProvider2.initialize(
+                CTDL_WBTC_CURVE_POOL,
+                WBTC_BTC_PRICE_FEED,
+                BTC_USD_PRICE_FEED,
+                assetEthFeeds[i]
+            );
             _checkedLatestData(address(ctdlAssetProvider2));
         }
     }


### PR DESCRIPTION
> Note: Decided to not pursue this option but leaving up for posterity

## Overview
- To facilitate a smooth atomic launch, we want to initialize the oracles after deployment. This is because the curve pool address only becomes known during that process.
- we could deploy the oracles fresh during the atomic launch when we know the curve pool address, but want the etherscan situation to work out definitely beforehand

### Downsides
- lose benefits of immutable
- introduce smart contract risk via the initializer 